### PR TITLE
Add manjaro as arch-based distro

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -9,7 +9,7 @@ elif grep ID /etc/os-release | grep -q debian; then
 	sudo apt-get install gcc unzip wget zip gcc-avr binutils-avr avr-libc \
 	    dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi \
 	    libnewlib-arm-none-eabi
-elif grep ID /etc/os-release | grep -q arch; then
+elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 	sudo pacman -S gcc unzip wget zip avr-gcc avr-binutils avr-libc \
 	    dfu-util arm-none-eabi-gcc arm-none-eabi-binutils \
 	    arm-none-eabi-newlib


### PR DESCRIPTION
The check in `linux_install.sh` can be expanded to recognize Manjaro as an Arch-based distro. The rest of the install script works because pacman is also available.